### PR TITLE
 Support not specifying "base" Ignition file

### DIFF
--- a/filetranspile
+++ b/filetranspile
@@ -68,8 +68,7 @@ def main():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-i', '--ignition', help='Path to ignition file to use as the base',
-        required=True)
+        '-i', '--ignition', help='Path to ignition file to use as the base')
     parser.add_argument(
         '-f', '--fake-root', help='Path to the fake root',
         required=True)
@@ -85,10 +84,13 @@ def main():
 
     args = parser.parse_args()
 
-    # Open the ignition file and load it
-    with open(args.ignition, 'r') as f:
-        # Get the ignition config
-        ignition_cfg = json.load(f)
+    # Open the base ignition file and load it
+    if args.ignition is not None:
+        with open(args.ignition, 'r') as f:
+            # Get the ignition config
+            ignition_cfg = json.load(f)
+    else:
+        ignition_cfg = { "ignition": { "version": "2.3.0" } }
 
     # Walk through the files and append them for merging
     all_files = []

--- a/filetranspile
+++ b/filetranspile
@@ -90,33 +90,33 @@ def main():
         # Get the ignition config
         ignition_cfg = json.load(f)
 
-        # Walk through the files and append them for merging
-        all_files = []
-        for root, _, files in os.walk(args.fake_root):
-            for file in files:
-                path = os.path.sep.join([root, file])
-                host_path = path.replace(args.fake_root, '')
-                if not host_path.startswith(os.path.sep):
-                    host_path = os.path.sep + host_path
-                mode = oct(stat.S_IMODE(os.stat(path).st_mode))
-                with open(path, 'r') as file_obj:
-                    snippet = file_to_ignition(
-                        host_path, file_obj.read(), mode)
-                all_files.append(snippet)
+    # Walk through the files and append them for merging
+    all_files = []
+    for root, _, files in os.walk(args.fake_root):
+        for file in files:
+            path = os.path.sep.join([root, file])
+            host_path = path.replace(args.fake_root, '')
+            if not host_path.startswith(os.path.sep):
+                host_path = os.path.sep + host_path
+            mode = oct(stat.S_IMODE(os.stat(path).st_mode))
+            with open(path, 'r') as file_obj:
+                snippet = file_to_ignition(
+                    host_path, file_obj.read(), mode)
+            all_files.append(snippet)
 
-        # Merge the and output the results
-        merged_ignition = merge_with_ignition(ignition_cfg, all_files)
-        if args.pretty:
-            ignition_out = json.dumps(
-                merged_ignition, sort_keys=True,
-                indent=4, separators=(',', ': '))
-        else:
-            ignition_out = json.dumps(merged_ignition)
-        if args.output:
-            with open(args.output, 'w') as out_f:
-                out_f.write(ignition_out)
-        else:
-            print(ignition_out)
+    # Merge the and output the results
+    merged_ignition = merge_with_ignition(ignition_cfg, all_files)
+    if args.pretty:
+        ignition_out = json.dumps(
+            merged_ignition, sort_keys=True,
+            indent=4, separators=(',', ': '))
+    else:
+        ignition_out = json.dumps(merged_ignition)
+    if args.output:
+        with open(args.output, 'w') as out_f:
+            out_f.write(ignition_out)
+    else:
+        print(ignition_out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

`cosa run` as of recently can do merging, so it's convenient
to use this project to generate *partial* files and rely
on `cosa run -i` to merge into its base.  Previously
I was passing `-i /path/to/dummy.ign` here.