### PR TITLE
README.md: Minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # filetranspiler
-Creates an update `Ignition` json file with additions from a fake root.
+Creates an [Ignition](https://github.com/coreos/ignition) JSON file from a fake root.
+
+See also [fcct](https://github.com/coreos/fcct).
 
 ## Building
 


### PR DESCRIPTION
I think backticks \`\` in Markdown should only be used for things
that one would type at a terminal, basically.   So `Ignition`
isn't right because one would never type it as a command or argument.
And in this case it's more useful to link to the project Github page.

Also link to fcct while we're here.