### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.fedoraproject.org/fedora:latest
 
 COPY filetranspile /usr/bin/filetranspile
 
-RUN dnf update -y && \
+RUN dnf update -y && dnf install -y python3-pyyaml &&\
     chmod a+x /usr/bin/filetranspile
 
 WORKDIR /srv


### PR DESCRIPTION
fix `"ModuleNotFoundError: No module named 'yaml'"` error  with `dnf install python3-pyyaml`

```
# podman run -it localhost/filetranspiler bash
Traceback (most recent call last):
  File "/usr/bin/filetranspile", line 12, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```