### PR TITLE
Add validation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 __pycache__
+ignition-validate

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,14 @@ help:
 	@echo "Targets"
 	@echo "- help: The thing you are reading right now"
 	@echo "- test: Run basic testing"
+	@echo "- get-validator: Download ignition validator from GitHub"
 	@echo "- container: Build the container image locally with podman"
+
+.PHONY: get-validator
+get-validator:
+	wget https://github.com/coreos/ignition/releases/download/v0.35.0/ignition-validate-x86_64-linux
+	mv ignition-validate-x86_64-linux ignition-validate
+	chmod a+x ignition-validate
 
 .PHONY: test
 test:

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+# If IGNITION_VALIDATE is not set to a specific binary
+# check to see if we have it locally
+if [[ -z ${IGNITION_VALIDATE} ]]; then
+    # Check local directory
+    ls ignition-validate 2>&1 /dev/null
+    if [[ $? == 0 ]]; then
+        IGNITION_VALIDATE="$(pwd)/ignition-validate"
+    else
+        echo "- ignition-validate not found. Skipping validation."
+    fi
+fi
+
+if [[ ${IGNITION_VALIDATE} != "" ]]; then
+    echo "+ Found ignition-validate at ${IGNITION_VALIDATE}"
+    echo "+ $(${IGNITION_VALIDATE} --version)"
+fi
+
 NEWFILES='"/etc/hostname"
 "/etc/resolve.conf"
 "/etc/sysconfig/network-scripts/ifcfg-fake"
@@ -18,6 +35,22 @@ for required_command in jq file; do
         exit 1
     fi
 done
+
+# validate the output (if ignition-validate is available)
+validate_ignition() {
+    tmpfile=$1
+    testname=$2
+    if [[ ${IGNITION_VALIDATE} != "" ]]; then
+        ${IGNITION_VALIDATE} $tmpfile
+        if [[ $? == 0 ]]; then
+            echo "PASS: Validate config for ${testname}"
+        else
+            echo "FAIL: Validation failed for ${testname}"
+        fi
+    else
+        echo "SKIP: Can not validate file for ${testname}"
+    fi
+}
 
 # Ensure the new files from the fakeroot are present
 test_expected_files() {
@@ -97,18 +130,21 @@ test_expected_contents() {
 test_name="Ignition With No Storage"
 tmpfile=$(mktemp)
 ./filetranspile -i test/ignition-no-storage.json -f test/fakeroot > ${tmpfile}
+validate_ignition "${tmpfile}" "${test_name}"
 test_expected_files "${tmpfile}" "${test_name}"
 test_expected_keys "${tmpfile}" "${test_name}"
 
 test_name="Ignition With No Files"
 tmpfile=$(mktemp)
 ./filetranspile -i test/ignition-no-files.json -f test/fakeroot > ${tmpfile}
+validate_ignition "${tmpfile}" "${test_name}"
 test_expected_files "${tmpfile}" "${test_name}"
 test_expected_keys "${tmpfile}" "${test_name}"
 
 test_name="Ignition With Existing Files"
 tmpfile=$(mktemp)
 ./filetranspile -i test/ignition.json -f test/fakeroot > ${tmpfile}
+validate_ignition "${tmpfile}" "${test_name}"
 test_expected_files "${tmpfile}" "${test_name}"
 test_expected_keys "${tmpfile}" "${test_name}"
 
@@ -116,6 +152,7 @@ test_expected_keys "${tmpfile}" "${test_name}"
 test_name="Ignition Overwrite With Fakeroot File"
 tmpfile=$(mktemp)
 ./filetranspile -i test/ignition-overwrite-with-fakeroot-file.json -f test/fakeroot > ${tmpfile}
+validate_ignition "${tmpfile}" "${test_name}"
 test_expected_files "${tmpfile}" "${test_name}"
 test_expected_keys "${tmpfile}" "${test_name}"
 # We should still have the fakeroot one and not the one in our original ignition


### PR DESCRIPTION
# Grabbing ignition-validate
```
$ make get-validator 
wget https://github.com/coreos/ignition/releases/download/v0.35.0/ignition-validate-x86_64-linux
<snip>
HTTP request sent, awaiting response... 200 OK
Length: 7776928 (7.4M) [application/octet-stream]
Saving to: ‘ignition-validate-x86_64-linux’

ignition-validate-x86_64-linux       100%[=====================================================================>]   7.42M  9.82MB/s    in 0.8s    

2020-03-10 14:37:26 (9.82 MB/s) - ‘ignition-validate-x86_64-linux’ saved [7776928/7776928]

mv ignition-validate-x86_64-linux ignition-validate
chmod a+x ignition-validate
$
```


# With ignition-validate
```
$ make test
./test/test.sh
/dev/null  ignition-validate
+ Found ignition-validate at [....]/ignition-validate
+ Ignition 0.35.0
PASS: Validate config for Ignition With No Storage
PASS: Ignition With No Storage: File Check
PASS: Ignition With No Storage: Key Check
PASS: Validate config for Ignition With No Files
PASS: Ignition With No Files: File Check
PASS: Ignition With No Files: Key Check
PASS: Validate config for Ignition With Existing Files
PASS: Ignition With Existing Files: File Check
PASS: Ignition With Existing Files: Key Check
$ echo $?
0
$
```

# Without ignition-validate
```
$ make test
./test/test.sh
ls: cannot access 'ignition-validate': No such file or directory
/dev/null
- ignition-validate not found. Skipping validation.
SKIP: Can not validate file for Ignition With No Storage
PASS: Ignition With No Storage: File Check
PASS: Ignition With No Storage: Key Check
SKIP: Can not validate file for Ignition With No Files
PASS: Ignition With No Files: File Check
PASS: Ignition With No Files: Key Check
SKIP: Can not validate file for Ignition With Existing Files
PASS: Ignition With Existing Files: File Check
PASS: Ignition With Existing Files: Key Check
$ echo $?
0
$
```