### PR TITLE
Update dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ These items are required when running outside of the container.
 - Python 3 (3.6+ recommended)
 - [PyYAML](https://github.com/yaml/pyyaml)
 - python3-magic
+- file-magic
 
 ```
 ./filetranspile -i ignition.json -f fake-root


### PR DESCRIPTION
This application also depends on the file-magic Python package. It is used by python3-magic, but not automatically installed when installing python-magic via pip.