### PR TITLE
test: Test overwrite logic

### DIFF
--- a/test/ignition-overwrite-with-fakeroot-file.json
+++ b/test/ignition-overwrite-with-fakeroot-file.json
@@ -1,0 +1,17 @@
+{
+  "ignition": { "version": "2.3.0" },
+  "storage": {
+    "files": [{
+      "path": "/foo/bar",
+      "filesystem": "root",
+      "mode": 420,
+      "contents": { "source": "data:,example%20file%0A" }
+    },
+    {
+      "path": "/etc/resolve.conf",
+      "filesystem": "root",
+      "mode": 420,
+      "contents": { "source": "data:,dontuseme%20file%0A" }
+    }]
+  }
+}


### PR DESCRIPTION
When a file is in the original ignition and it's in our fakeroot
we now overwrite the ignition version with what the fakeroot
provides. This adds tests to ensure we don't break that logic.

See: https://github.com/ashcrow/filetranspiler/pull/29

cc  @m-yosefpor